### PR TITLE
fix: Support DateTimeImmutable

### DIFF
--- a/DBAL/Types/UtcDateTimeType.php
+++ b/DBAL/Types/UtcDateTimeType.php
@@ -34,7 +34,7 @@ class UtcDateTimeType extends DateTimeType
             return null;
         }
 
-        if ($date instanceof DateTime) {
+        if ($date instanceof \DateTimeInterface) {
             return parent::convertToDatabaseValue($date->setTimezone($this::getUTC()), $platform);
         }
 

--- a/DBAL/Types/UtcDateType.php
+++ b/DBAL/Types/UtcDateType.php
@@ -34,7 +34,7 @@ class UtcDateType extends DateType
             return null;
         }
 
-        if ($date instanceof DateTime) {
+        if ($date instanceof \DateTimeInterface) {
             return parent::convertToDatabaseValue($date->setTimezone($this::getUTC()), $platform);
         }
 

--- a/DBAL/Types/UtcTimeType.php
+++ b/DBAL/Types/UtcTimeType.php
@@ -34,7 +34,7 @@ class UtcTimeType extends TimeType
             return null;
         }
 
-        if ($date instanceof DateTime) {
+        if ($date instanceof \DateTimeInterface) {
             return parent::convertToDatabaseValue($date->setTimezone($this::getUTC()), $platform);
         }
 


### PR DESCRIPTION
Fixes ConvertException:
`Could not convert PHP value of type 'DateTimeImmutable' to type 'datetime'. Expected one of the following types: null, DateTime  `
